### PR TITLE
Fix path building for custom characters

### DIFF
--- a/src-tauri/src/scripts/local_characters_functions.rs
+++ b/src-tauri/src/scripts/local_characters_functions.rs
@@ -17,7 +17,7 @@ struct Output {
 
 #[command]
 pub fn get_character_informations(path: &Path) -> String {
-    let base_path = Path::new(&path);
+    let base_path = path;
     let custom_characters_path = base_path
         .join("user")
         .join("client")

--- a/src-tauri/src/scripts/local_characters_functions.rs
+++ b/src-tauri/src/scripts/local_characters_functions.rs
@@ -18,7 +18,11 @@ struct Output {
 #[command]
 pub fn get_character_informations(path: &Path) -> String {
     let base_path = Path::new(&path);
-    let custom_characters_path = format!("{:?}\\user\\client\\0\\customcharacters", base_path);
+    let custom_characters_path = base_path
+        .join("user")
+        .join("client")
+        .join("0")
+        .join("customcharacters");
 
     let mut characters = Vec::new();
 
@@ -33,7 +37,11 @@ pub fn get_character_informations(path: &Path) -> String {
             }
         }
         Err(e) => {
-            println!("Erreur lors de l'accès au répertoire {}: {}", custom_characters_path, e);
+            println!(
+                "Erreur lors de l'accès au répertoire {}: {}",
+                custom_characters_path.display(),
+                e
+            );
         }
     }
 
@@ -71,10 +79,14 @@ pub fn delete_character(path: &str) -> bool {
 #[command]
 pub fn open_characters_folder(path: &Path) -> Result<bool, String> {
     let base_path = Path::new(&path);
-    let custom_characters_path = format!("{:?}\\user\\client\\0\\customcharacters", base_path);
+    let custom_characters_path = base_path
+        .join("user")
+        .join("client")
+        .join("0")
+        .join("customcharacters");
 
         // Vérifie si le chemin existe
-        if std::path::Path::new(&custom_characters_path).exists() {
+        if custom_characters_path.exists() {
             // Ouvre le dossier dans l'explorateur de fichiers
             Command::new("explorer")
                 .arg(&custom_characters_path)
@@ -82,6 +94,6 @@ pub fn open_characters_folder(path: &Path) -> Result<bool, String> {
                 .map_err(|e| format!("Erreur lors de l'ouverture du dossier : {}", e))?;
             Ok(true)
         } else {
-            Err(format!("Le dossier '{}' n'existe pas.", custom_characters_path))
+            Err(format!("Le dossier '{}' n'existe pas.", custom_characters_path.display()))
         }
 }


### PR DESCRIPTION
## Summary
- build custom characters path using `PathBuf::join`
- directly use the path with filesystem operations

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: `gio-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68695bdc45788326a7f24f8ea02b2996