### PR TITLE
Fix Tauri path parameters

### DIFF
--- a/src-tauri/src/scripts/local_characters_functions.rs
+++ b/src-tauri/src/scripts/local_characters_functions.rs
@@ -16,7 +16,7 @@ struct Output {
 }
 
 #[command]
-pub fn get_character_informations(path: &Path) -> String {
+pub fn get_character_informations(path: String) -> String {
     let base_path = Path::new(&path);
     let custom_characters_path = format!("{:?}\\user\\client\\0\\customcharacters", base_path);
 
@@ -69,7 +69,7 @@ pub fn delete_character(path: &str) -> bool {
 }
 
 #[command]
-pub fn open_characters_folder(path: &Path) -> Result<bool, String> {
+pub fn open_characters_folder(path: String) -> Result<bool, String> {
     let base_path = Path::new(&path);
     let custom_characters_path = format!("{:?}\\user\\client\\0\\customcharacters", base_path);
 


### PR DESCRIPTION
## Summary
- update `get_character_informations` and `open_characters_folder` to accept `String`
- convert incoming strings to `Path` internally

## Testing
- `cargo check` *(fails: gdk-3.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_b_68695bf485048326b46c359e5f463aac