### PR TITLE
Renommage fonctions presets locaux

### DIFF
--- a/src/components/custom/local-characters-presets/actions.tsx
+++ b/src/components/custom/local-characters-presets/actions.tsx
@@ -8,7 +8,11 @@ import { Ellipsis } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useToast } from "@/hooks/use-toast";
 
-export default function ActionsMenu({ setCacheInfos }: { setCacheInfos: any }) {
+export default function ActionsMenu({
+    setLocalCharacters,
+}: {
+    setLocalCharacters: any;
+}) {
     const { toast } = useToast();
     const handleOpenCacheFolder = async () => {
         try {
@@ -34,7 +38,7 @@ export default function ActionsMenu({ setCacheInfos }: { setCacheInfos: any }) {
         try {
             const res = await invoke("clear_cache");
             if (res) {
-                setCacheInfos([]);
+                setLocalCharacters([]);
                 toast({
                     title: "Cache nettoyé",
                     description: "Le cache a bien été nettoyé.",

--- a/src/components/custom/local-characters-presets/columns.tsx
+++ b/src/components/custom/local-characters-presets/columns.tsx
@@ -2,53 +2,8 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { Trash } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
-
-export interface RemoteCharactersPresetsList {
-    body: Body;
-    path: string;
-    query: string;
-    cookies: any[];
-}
-
-export interface Body {
-    hasPrevPage: boolean;
-    hasNextPage: boolean;
-    rows: Row[];
-}
-
-export interface Row {
-    id: string;
-    createdAt: Date;
-    title: string;
-    tags: any[];
-    user: User;
-    previewUrl: string;
-    dnaUrl: string;
-    _count: Count;
-}
-
-export interface Count {
-    characterDownloads: number;
-    characterLikes: number;
-}
-
-export interface User {
-    id: string;
-    name: string;
-    image: string;
-    starCitizenHandle: string;
-}
-
-// Renommé pour correspondre au type utilisé dans columns.tsx
-export interface Character {
-    name: string;
-    path: string;
-    version: string;
-}
-
-export interface LocalCharactersResult {
-    characters: Character[];
-}
+import { LocalCharacter as Character } from "@/types/charactersList";
+export type { Character };
 
 const deleteCharacter = async (
     path: string,

--- a/src/pages/LocalCharactersPresets.tsx
+++ b/src/pages/LocalCharactersPresets.tsx
@@ -14,8 +14,8 @@ function LocalCharactersPresets() {
     const [gamePaths, setGamePaths] = useState<GamePaths | null>(null);
     const { toast } = useToast();
 
-    const scanCache = useCallback(async (gamePath: string) => {
-        console.log("ScanCache called with path:", gamePath);
+    const scanLocalCharacters = useCallback(async (gamePath: string) => {
+        console.log("scanLocalCharacters called with path:", gamePath);
         try {
             const result: LocalCharactersResult = JSON.parse(
                 await invoke("get_character_informations", { path: gamePath }),
@@ -77,13 +77,13 @@ function LocalCharactersPresets() {
                 .filter(Boolean);
 
             for (const path of paths) {
-                await scanCache(path);
+                await scanLocalCharacters(path);
             }
             setIsLoading(false);
         };
 
         scanAllPaths();
-    }, [gamePaths, scanCache]);
+    }, [gamePaths, scanLocalCharacters]);
 
     // Animation des points de chargement
     useEffect(() => {


### PR DESCRIPTION
## Summary
- ajuster ActionsMenu pour utiliser `setLocalCharacters`
- renommer `scanCache` en `scanLocalCharacters`
- simplifier les types dans `columns.tsx`

## Testing
- `pnpm build` *(échoue : src/pages/Traduction.tsx(20,12): error TS6133)*

------
https://chatgpt.com/codex/tasks/task_b_686a9c3309d08326a3ba781cfa00ef84